### PR TITLE
Added a quick fix to #36

### DIFF
--- a/src/algorithms/ECDSA.js
+++ b/src/algorithms/ECDSA.js
@@ -163,8 +163,12 @@ class ECDSA extends Algorithm {
         // TODO may need to remove -noout if ec params is needed
         let privateKey = spawnSync('openssl', ['ecparam','-name',osslCurveName.name,'-genkey','-noout']).stdout
         let publicKey = spawnSync('openssl', ['ec', '-pubout'], { input: privateKey }).stdout
-        keypair.privateKey = privateKey.toString('ascii').trim()
-        keypair.publicKey = publicKey.toString('ascii').trim()
+        try {
+          keypair.privateKey = privateKey.toString('ascii').trim()
+          keypair.publicKey = publicKey.toString('ascii').trim()
+        } catch(error){
+          throw new OperationError(error.message)
+        }
     } catch (error) {
     // 3. If any operation fails then throw error
       throw new OperationError(error.message)

--- a/src/algorithms/RSASSA-PKCS1-v1_5.js
+++ b/src/algorithms/RSASSA-PKCS1-v1_5.js
@@ -143,9 +143,12 @@ class RSASSA_PKCS1_v1_5 extends Algorithm {
       let privateKey = spawnSync('openssl', ['genrsa', modulusLength || 4096]).stdout
       let publicKey = spawnSync('openssl', ['rsa', '-pubout'], { input: privateKey }).stdout
 
+	  try{
       keypair.privateKey = privateKey.toString('ascii')
       keypair.publicKey = publicKey.toString('ascii')
-
+	  } catch (error){
+	    throw new OperationError(error.message)
+	  }
       // - what is this bit option, where do we get the value from in this api?
       //let key = new RSA({b:512})
       //let {modulusLength,publicExponent} = params

--- a/src/algorithms/RSASSA-PKCS1-v1_5.js
+++ b/src/algorithms/RSASSA-PKCS1-v1_5.js
@@ -142,13 +142,12 @@ class RSASSA_PKCS1_v1_5 extends Algorithm {
       // - fallback on node-rsa if OpenSSL is not available on the system
       let privateKey = spawnSync('openssl', ['genrsa', modulusLength || 4096]).stdout
       let publicKey = spawnSync('openssl', ['rsa', '-pubout'], { input: privateKey }).stdout
-
-	  try{
-      keypair.privateKey = privateKey.toString('ascii')
-      keypair.publicKey = publicKey.toString('ascii')
-	  } catch (error){
-	    throw new OperationError(error.message)
-	  }
+      try {
+        keypair.privateKey = privateKey.toString('ascii')
+        keypair.publicKey = publicKey.toString('ascii')
+      } catch (error){
+        throw new OperationError(error.message)
+      }
       // - what is this bit option, where do we get the value from in this api?
       //let key = new RSA({b:512})
       //let {modulusLength,publicExponent} = params


### PR DESCRIPTION
I added a `try` `catch` block to check if either `privateKey` or `publicKey` don't have toString method attach to them. This would give us an indication that `openssl` command failed to execute.
 