### PR TITLE
chore(npm): add types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare var crypto: Crypto
+export = crypto;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.3",
   "description": "WebCrypto API for Node.js",
   "main": "src/index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
If this is intended to be a drop-in for WebCrypto, the built-in Crypto type can be used.

related-to: #60 