### PR TITLE
Isomorphic require

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,7 @@
+'use strict'
+
+/**
+ * Export
+ * @ignore
+ */
+module.exports = window.crypto

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.2",
   "description": "WebCrypto API for Node.js",
   "main": "src/index.js",
+  "browser": "browser.js",
   "types": "index.d.ts",
   "directories": {
     "test": "test"


### PR DESCRIPTION
A simple quality-of-life fix as discussed in #57.

Unsure if this actually works or does what it's meant to as we have no browser tests, but this should make webcrypto easier to use in isomorphic packages.