### PR TITLE
fix: allow passing an algorithm name to digest

### DIFF
--- a/src/SubtleCrypto.js
+++ b/src/SubtleCrypto.js
@@ -176,7 +176,7 @@ class SubtleCrypto {
 
     return new Promise((resolve, reject) => {
       try {
-        let result = normalizedAlgorithm.digest(algorithm, data)
+        let result = normalizedAlgorithm.digest(normalizedAlgorithm, data)
         return resolve(result)
       } catch (error) {
         return reject(error)

--- a/test/SubtleCryptoSpec.js
+++ b/test/SubtleCryptoSpec.js
@@ -596,25 +596,50 @@ describe('SubtleCrypto', () => {
     })
 
     describe('with valid arguments', () => {
-      let promise, error
+      describe('passing the algorithm as an object', () => {
+        let promise, error
 
-      beforeEach(() => {
-        let algorithm = { name: 'SHA-256' }
-        promise = crypto.subtle.digest(algorithm, new Buffer('whatever'))
-        promise.then(digest => result = digest)
-        promise.catch(err => error = err)
+        beforeEach(() => {
+          let algorithm = { name: 'SHA-256' }
+          promise = crypto.subtle.digest(algorithm, new Buffer('whatever'))
+          promise.then(digest => result = digest)
+          promise.catch(err => error = err)
+        })
+
+        it('should return a promise', () => {
+          promise.should.be.instanceof(Promise)
+        })
+
+        it('should resolve an ArrayBuffer', () => {
+          result.should.be.instanceof(ArrayBuffer)
+        })
+
+        it('should not reject the promise', () => {
+          expect(error).to.be.undefined
+        })
       })
 
-      it('should return a promise', () => {
-        promise.should.be.instanceof(Promise)
-      })
+      describe('passing the algorithm as a string', () => {
+        let promise, error
 
-      it('should resolve an ArrayBuffer', () => {
-        result.should.be.instanceof(ArrayBuffer)
-      })
+        beforeEach(() => {
+          let algorithm = 'SHA-256'
+          promise = crypto.subtle.digest(algorithm, new Buffer('whatever'))
+          promise.then(digest => result = digest)
+          promise.catch(err => error = err)
+        })
 
-      it('should not reject the promise', () => {
-        expect(error).to.be.undefined
+        it('should return a promise', () => {
+          promise.should.be.instanceof(Promise)
+        })
+
+        it('should resolve an ArrayBuffer', () => {
+          result.should.be.instanceof(ArrayBuffer)
+        })
+
+        it('should not reject the promise', () => {
+          expect(error).to.be.undefined
+        })
       })
     })
   })


### PR DESCRIPTION
The examples on [MDN][1] show strings passed as the first argument. I've tested that it actually works in browsers.

The [specification][2] shows `AlgorithmIdentifier` as the first argument to `digest` and `AlgorithmIdentifier` is defined as `typedef (object or DOMString) AlgorithmIdentifier;`

[1]: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
[2]: https://www.w3.org/TR/WebCryptoAPI/#subtlecrypto-interface

----

I've only briefly looked at the rest of the API but it seems to me the problem recurs elsewhere: the algorithm is normalized but instead of passing the normalized algorithm to the backend code, the original unnormalized value is passed. I only depend on `digest` right now and do not use the rest of the API so I've decided to not touch the rest of the API, but I suspect a similar change needs to be applied to other API functions.