### PR TITLE
Add support for Webpack's NodeJS targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,24 +53,17 @@ encourage or provide a [native, if not core][wtf] Web Cryptography module.
 $ npm install @trust/webcrypto --save
 ```
 
-### Not for use in Webpack
+### Usage in Webpack
 
-This library is not for use in Webpack.
-
-The whole point of this library is that it's an exact duplicate of the browser's WebCrypto API,
-for the server side.
-
-For Webpacked web applications,
-you don't need it (and can't use it).
-If this module is transitively included by another dependency,
-you have to exclude it by adding it to the [`externals` section in the Webpack config](https://webpack.js.org/configuration/externals/),
-such as this:
+If using `target`: `"web"` | `"web-worker`, you need to add the following configuration to your `externals` section to tell Webpack to use the existing browser implementation:
 
 ```
 externals: {
   '@trust/webcrypto': 'crypto'
 }
 ```
+
+Using other NodeJS-based targets (`"node"`, `"async-node"`, `"electron-main"`, etc.) should work as expected.
 
 ## Usage
 

--- a/src/algorithms/SupportedAlgorithms.js
+++ b/src/algorithms/SupportedAlgorithms.js
@@ -48,9 +48,9 @@ class SupportedAlgorithms {
   /**
    * Define Algorithm
    */
-  define (alg, op, type) {
+  define (alg, op, implementation) {
     let registeredAlgorithms = this[op]
-    registeredAlgorithms[alg] = type
+    registeredAlgorithms[alg] = implementation
   }
 
   /**
@@ -81,7 +81,11 @@ class SupportedAlgorithms {
       let desiredType, normalizedAlgorithm
 
       try {
-        desiredType = require(registeredAlgorithms[algName])
+        let createAlgorithm = registeredAlgorithms[algName]
+        if(typeof createAlgorithm !== "function") {
+          return new NotSupportedError(algName)
+        }
+        desiredType = createAlgorithm()
         normalizedAlgorithm = new desiredType(alg)
         normalizedAlgorithm.name = algName
       } catch (error) {

--- a/src/algorithms/index.js
+++ b/src/algorithms/index.js
@@ -11,48 +11,48 @@ const supportedAlgorithms = new SupportedAlgorithms()
 /**
  * encrypt
  */
-supportedAlgorithms.define('RSA-OAEP', 'encrypt', '../algorithms/RSA-OAEP')
-supportedAlgorithms.define('AES-CTR', 'encrypt', '../algorithms/AES-CTR')
-supportedAlgorithms.define('AES-CBC', 'encrypt', '../algorithms/AES-CBC')
-supportedAlgorithms.define('AES-GCM', 'encrypt', '../algorithms/AES-GCM')
+supportedAlgorithms.define('RSA-OAEP', 'encrypt', () => require('../algorithms/RSA-OAEP'))
+supportedAlgorithms.define('AES-CTR', 'encrypt', () => require('../algorithms/AES-CTR'))
+supportedAlgorithms.define('AES-CBC', 'encrypt', () => require('../algorithms/AES-CBC'))
+supportedAlgorithms.define('AES-GCM', 'encrypt', () => require('../algorithms/AES-GCM'))
 //supportedAlgorithms.define('AES-CFB', 'encrypt', )
 
 /**
  * decrypt
  */
-supportedAlgorithms.define('RSA-OAEP', 'decrypt', '../algorithms/RSA-OAEP')
-supportedAlgorithms.define('AES-CTR', 'decrypt', '../algorithms/AES-CTR')
-supportedAlgorithms.define('AES-CBC', 'decrypt', '../algorithms/AES-CBC')
-supportedAlgorithms.define('AES-GCM', 'decrypt', '../algorithms/AES-GCM')
+supportedAlgorithms.define('RSA-OAEP', 'decrypt', () => require('../algorithms/RSA-OAEP'))
+supportedAlgorithms.define('AES-CTR', 'decrypt', () => require('../algorithms/AES-CTR'))
+supportedAlgorithms.define('AES-CBC', 'decrypt', () => require('../algorithms/AES-CBC'))
+supportedAlgorithms.define('AES-GCM', 'decrypt', () => require('../algorithms/AES-GCM'))
 //supportedAlgorithms.define('AES-CFB', 'decrypt', )
 
 /**
  * sign
  */
-supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'sign', '../algorithms/RSASSA-PKCS1-v1_5')
-supportedAlgorithms.define('RSA-PSS', 'sign', '../algorithms/RSA-PSS')
-supportedAlgorithms.define('ECDSA', 'sign', '../algorithms/ECDSA')
-supportedAlgorithms.define('EDDSA', 'sign', '../algorithms/EDDSA')
+supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'sign', () => require('../algorithms/RSASSA-PKCS1-v1_5'))
+supportedAlgorithms.define('RSA-PSS', 'sign', () => require('../algorithms/RSA-PSS'))
+supportedAlgorithms.define('ECDSA', 'sign', () => require('../algorithms/ECDSA'))
+supportedAlgorithms.define('EDDSA', 'sign', () => require('../algorithms/EDDSA'))
 //supportedAlgorithms.define('AES-CMAC', 'sign', )
-supportedAlgorithms.define('HMAC', 'sign', '../algorithms/HMAC')
+supportedAlgorithms.define('HMAC', 'sign', () => require('../algorithms/HMAC'))
 
 /**
  * verify
  */
-supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'verify', '../algorithms/RSASSA-PKCS1-v1_5')
-supportedAlgorithms.define('RSA-PSS', 'verify', '../algorithms/RSA-PSS')
-supportedAlgorithms.define('ECDSA', 'verify', '../algorithms/ECDSA')
-supportedAlgorithms.define('EDDSA', 'verify', '../algorithms/EDDSA')
+supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'verify', () => require('../algorithms/RSASSA-PKCS1-v1_5'))
+supportedAlgorithms.define('RSA-PSS', 'verify', () => require('../algorithms/RSA-PSS'))
+supportedAlgorithms.define('ECDSA', 'verify', () => require('../algorithms/ECDSA'))
+supportedAlgorithms.define('EDDSA', 'verify', () => require('../algorithms/EDDSA'))
 //supportedAlgorithms.define('AES-CMAC', 'verify', )
-supportedAlgorithms.define('HMAC', 'verify', '../algorithms/HMAC')
+supportedAlgorithms.define('HMAC', 'verify', () => require('../algorithms/HMAC'))
 
 /**
  * digest
  */
-supportedAlgorithms.define('SHA-1', 'digest', '../algorithms/SHA')
-supportedAlgorithms.define('SHA-256', 'digest', '../algorithms/SHA')
-supportedAlgorithms.define('SHA-384', 'digest', '../algorithms/SHA')
-supportedAlgorithms.define('SHA-512', 'digest', '../algorithms/SHA')
+supportedAlgorithms.define('SHA-1', 'digest', () => require('../algorithms/SHA'))
+supportedAlgorithms.define('SHA-256', 'digest', () => require('../algorithms/SHA'))
+supportedAlgorithms.define('SHA-384', 'digest', () => require('../algorithms/SHA'))
+supportedAlgorithms.define('SHA-512', 'digest', () => require('../algorithms/SHA'))
 
 /**
  * deriveKey
@@ -75,38 +75,38 @@ supportedAlgorithms.define('SHA-512', 'digest', '../algorithms/SHA')
 /**
  * generateKey
  */
-supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'generateKey', '../algorithms/RSASSA-PKCS1-v1_5')
-supportedAlgorithms.define('RSA-PSS', 'generateKey', '../algorithms/RSA-PSS')
-supportedAlgorithms.define('RSA-OAEP', 'generateKey', '../algorithms/RSA-OAEP')
-supportedAlgorithms.define('ECDSA', 'generateKey', '../algorithms/ECDSA')
-supportedAlgorithms.define('EDDSA', 'generateKey', '../algorithms/EDDSA')
+supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'generateKey', () => require('../algorithms/RSASSA-PKCS1-v1_5'))
+supportedAlgorithms.define('RSA-PSS', 'generateKey', () => require('../algorithms/RSA-PSS'))
+supportedAlgorithms.define('RSA-OAEP', 'generateKey', () => require('../algorithms/RSA-OAEP'))
+supportedAlgorithms.define('ECDSA', 'generateKey', () => require('../algorithms/ECDSA'))
+supportedAlgorithms.define('EDDSA', 'generateKey', () => require('../algorithms/EDDSA'))
 //supportedAlgorithms.define('ECDH', 'generateKey', )
-supportedAlgorithms.define('AES-CTR', 'generateKey', '../algorithms/AES-CTR')
-supportedAlgorithms.define('AES-CBC', 'generateKey', '../algorithms/AES-CBC')
+supportedAlgorithms.define('AES-CTR', 'generateKey', () => require('../algorithms/AES-CTR'))
+supportedAlgorithms.define('AES-CBC', 'generateKey', () => require('../algorithms/AES-CBC'))
 //supportedAlgorithms.define('AES-CMAC', 'generateKey', )
-supportedAlgorithms.define('AES-GCM', 'generateKey', '../algorithms/AES-GCM')
+supportedAlgorithms.define('AES-GCM', 'generateKey', () => require('../algorithms/AES-GCM'))
 //supportedAlgorithms.define('AES-CFB', 'generateKey', )
-supportedAlgorithms.define('AES-KW', 'generateKey', '../algorithms/AES-KW')
-supportedAlgorithms.define('HMAC', 'generateKey', '../algorithms/HMAC')
+supportedAlgorithms.define('AES-KW', 'generateKey', () => require('../algorithms/AES-KW'))
+supportedAlgorithms.define('HMAC', 'generateKey', () => require('../algorithms/HMAC'))
 //supportedAlgorithms.define('DH', 'generateKey', )
 //supportedAlgorithms.define('PBKDF2', 'generateKey', )
 
 /**
  * importKey
  */
-supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'importKey', '../algorithms/RSASSA-PKCS1-v1_5')
-supportedAlgorithms.define('RSA-PSS', 'importKey', '../algorithms/RSA-PSS')
-supportedAlgorithms.define('RSA-OAEP', 'importKey', '../algorithms/RSA-OAEP')
-supportedAlgorithms.define('ECDSA', 'importKey', '../algorithms/ECDSA')
-supportedAlgorithms.define('EDDSA', 'importKey', '../algorithms/EDDSA')
+supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'importKey', () => require('../algorithms/RSASSA-PKCS1-v1_5'))
+supportedAlgorithms.define('RSA-PSS', 'importKey', () => require('../algorithms/RSA-PSS'))
+supportedAlgorithms.define('RSA-OAEP', 'importKey', () => require('../algorithms/RSA-OAEP'))
+supportedAlgorithms.define('ECDSA', 'importKey', () => require('../algorithms/ECDSA'))
+supportedAlgorithms.define('EDDSA', 'importKey', () => require('../algorithms/EDDSA'))
 //supportedAlgorithms.define('ECDH', 'importKey', )
-supportedAlgorithms.define('AES-CTR', 'importKey', '../algorithms/AES-CTR')
-supportedAlgorithms.define('AES-CBC', 'importKey', '../algorithms/AES-CBC')
+supportedAlgorithms.define('AES-CTR', 'importKey', () => require('../algorithms/AES-CTR'))
+supportedAlgorithms.define('AES-CBC', 'importKey', () => require('../algorithms/AES-CBC'))
 //supportedAlgorithms.define('AES-CMAC', 'importKey', )
-supportedAlgorithms.define('AES-GCM', 'importKey', '../algorithms/AES-GCM')
+supportedAlgorithms.define('AES-GCM', 'importKey', () => require('../algorithms/AES-GCM'))
 //supportedAlgorithms.define('AES-CFB', 'importKey', )
-supportedAlgorithms.define('AES-KW', 'importKey', '../algorithms/AES-KW')
-supportedAlgorithms.define('HMAC', 'importKey', '../algorithms/HMAC')
+supportedAlgorithms.define('AES-KW', 'importKey', () => require('../algorithms/AES-KW'))
+supportedAlgorithms.define('HMAC', 'importKey', () => require('../algorithms/HMAC'))
 //supportedAlgorithms.define('DH', 'importKey', )
 //supportedAlgorithms.define('CONCAT', 'importKey', )
 //supportedAlgorithms.define('HKDF-CTR', 'importKey', )
@@ -115,40 +115,40 @@ supportedAlgorithms.define('HMAC', 'importKey', '../algorithms/HMAC')
 /**
  * exportKey
  */
-supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'exportKey', '../algorithms/RSASSA-PKCS1-v1_5')
-supportedAlgorithms.define('RSA-PSS', 'exportKey', '../algorithms/RSA-PSS')
-supportedAlgorithms.define('RSA-OAEP', 'exportKey', '../algorithms/RSA-OAEP')
-supportedAlgorithms.define('EDDSA', 'exportKey', '../algorithms/EDDSA')
-supportedAlgorithms.define('ECDSA', 'exportKey', '../algorithms/ECDSA')
+supportedAlgorithms.define('RSASSA-PKCS1-v1_5', 'exportKey', () => require('../algorithms/RSASSA-PKCS1-v1_5'))
+supportedAlgorithms.define('RSA-PSS', 'exportKey', () => require('../algorithms/RSA-PSS'))
+supportedAlgorithms.define('RSA-OAEP', 'exportKey', () => require('../algorithms/RSA-OAEP'))
+supportedAlgorithms.define('EDDSA', 'exportKey', () => require('../algorithms/EDDSA'))
+supportedAlgorithms.define('ECDSA', 'exportKey', () => require('../algorithms/ECDSA'))
 //supportedAlgorithms.define('ECDH', 'exportKey', )
-supportedAlgorithms.define('AES-CTR', 'exportKey', '../algorithms/AES-CTR')
-supportedAlgorithms.define('AES-CBC', 'exportKey', '../algorithms/AES-CBC')
+supportedAlgorithms.define('AES-CTR', 'exportKey', () => require('../algorithms/AES-CTR'))
+supportedAlgorithms.define('AES-CBC', 'exportKey', () => require('../algorithms/AES-CBC'))
 //supportedAlgorithms.define('AES-CMAC', 'exportKey', )
-supportedAlgorithms.define('AES-GCM', 'exportKey', '../algorithms/AES-GCM')
+supportedAlgorithms.define('AES-GCM', 'exportKey', () => require('../algorithms/AES-GCM'))
 //supportedAlgorithms.define('AES-CFB', 'exportKey', )
-supportedAlgorithms.define('AES-KW', 'exportKey', '../algorithms/AES-KW')
-supportedAlgorithms.define('HMAC', 'exportKey', '../algorithms/HMAC')
+supportedAlgorithms.define('AES-KW', 'exportKey', () => require('../algorithms/AES-KW'))
+supportedAlgorithms.define('HMAC', 'exportKey', () => require('../algorithms/HMAC'))
 //supportedAlgorithms.define('DH', 'exportKey', )
 
 /**
  * wrapKey
  */
-supportedAlgorithms.define('RSA-OAEP', 'wrapKey', '../algorithms/RSA-OAEP')
-supportedAlgorithms.define('AES-CTR', 'wrapKey', '../algorithms/AES-CTR')
-supportedAlgorithms.define('AES-CBC', 'wrapKey', '../algorithms/AES-CBC')
-supportedAlgorithms.define('AES-GCM', 'wrapKey', '../algorithms/AES-GCM')
+supportedAlgorithms.define('RSA-OAEP', 'wrapKey', () => require('../algorithms/RSA-OAEP'))
+supportedAlgorithms.define('AES-CTR', 'wrapKey', () => require('../algorithms/AES-CTR'))
+supportedAlgorithms.define('AES-CBC', 'wrapKey', () => require('../algorithms/AES-CBC'))
+supportedAlgorithms.define('AES-GCM', 'wrapKey', () => require('../algorithms/AES-GCM'))
 //supportedAlgorithms.define('AES-CFB', 'wrapKey', )
-supportedAlgorithms.define('AES-KW', 'wrapKey', '../algorithms/AES-KW')
+supportedAlgorithms.define('AES-KW', 'wrapKey', () => require('../algorithms/AES-KW'))
 
 /**
  * unwrapKey
  */
-supportedAlgorithms.define('RSA-OAEP', 'unwrapKey', '../algorithms/RSA-OAEP')
-supportedAlgorithms.define('AES-CTR', 'unwrapKey', '../algorithms/AES-CTR')
-supportedAlgorithms.define('AES-CBC', 'unwrapKey', '../algorithms/AES-CBC')
-supportedAlgorithms.define('AES-GCM', 'unwrapKey', '../algorithms/AES-GCM')
+supportedAlgorithms.define('RSA-OAEP', 'unwrapKey', () => require('../algorithms/RSA-OAEP'))
+supportedAlgorithms.define('AES-CTR', 'unwrapKey', () => require('../algorithms/AES-CTR'))
+supportedAlgorithms.define('AES-CBC', 'unwrapKey', () => require('../algorithms/AES-CBC'))
+supportedAlgorithms.define('AES-GCM', 'unwrapKey', () => require('../algorithms/AES-GCM'))
 //supportedAlgorithms.define('AES-CFB', 'unwrapKey', )
-supportedAlgorithms.define('AES-KW', 'unwrapKey', '../algorithms/AES-KW')
+supportedAlgorithms.define('AES-KW', 'unwrapKey', () => require('../algorithms/AES-KW'))
 
 /**
  * Export


### PR DESCRIPTION
I know the README says [Not for use in Webpack](https://github.com/anvilresearch/webcrypto#not-for-use-in-webpack), but Webpack isn't only used for outputting browser code. When using a [target](https://webpack.js.org/configuration/target/) other than `web` (NodeJS, Electron, etc.) there's no reason this library shouldn't be able to be bundled using Webpack too.

The reason it doesn't work is because of this block of code:

https://github.com/anvilresearch/webcrypto/blob/5303c62ac2f0c0cef293d9a8d3d54e0b794149aa/src/algorithms/SupportedAlgorithms.js#L84

Webpack doesn't handle dynamic `require` very well.

This PR addresses the issue by turning the `registeredAlgorithms` into a factory function, rather than a path, allowing Webpack to effectively track which files should be bundled. This will allow users to use Webpack for any NodeJS target

